### PR TITLE
Updated to WDK 10.0.19041.685 and added call to install WDK VSIX package

### DIFF
--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -1,3 +1,4 @@
 ﻿. (Join-Path $(Split-Path -parent $MyInvocation.MyCommand.Definition) 'common.ps1')
 
 Install-ChocolateyPackage "$packageName" "$installerType" "$silentArgs" "$url" -checksum $checksum -checksumType $checksumType -validExitCodes $validExitCodes
+Install-VisualStudioVsixExtension -PackageName "WDK" -VsixUrl "${env:ProgramFiles(x86)}\Windows Kits\10\Vsix\VS2019\WDK.vsix"

--- a/tools/common.ps1
+++ b/tools/common.ps1
@@ -1,7 +1,7 @@
 ﻿$packageName = 'WindowsDriverKit10'
 $installerType = 'EXE'
-$url = 'http://download.microsoft.com/download/1/4/0/140EBDB7-F631-4191-9DC0-31C8ECB8A11F/wdk/wdksetup.exe'
+$url = 'https://download.microsoft.com/download/c/f/8/cf80b955-d578-4635-825c-2801911f9d79/wdk/wdksetup.exe'
 $silentArgs = '/features + /q /norestart'
 $validExitCodes = @(0)
-$checksum = '334BDE819DE7300A9DA8CA1DE50947E9E3A70EAD'
+$checksum = '8fe98523d0dda019cd24b7fdb4241f7e9dd63f24'
 $checksumType = 'sha1'

--- a/windowsdriverkit10.nuspec
+++ b/windowsdriverkit10.nuspec
@@ -4,7 +4,7 @@
   <metadata>
     <id>windowsdriverkit10</id>
     <title>Windows Driver Kit 10</title>
-    <version>10.0.17763</version>
+    <version>10.0.19041.685</version>
     <authors>Microsoft</authors>
     <owners>Nicolas Schneider</owners>
     <summary>This is the WDK Version 10 for use with Visual Studio 2017.</summary>


### PR DESCRIPTION
Hi, I've updated to the latest WDK 2004 as used here [Download the Windows Driver Kit (WDK)](https://docs.microsoft.com/en-us/windows-hardware/drivers/download-the-wdk#related-downloads ).

I've also added a line to install the Visual Studio WDK VSIX package which is included in the WDK.

If the changes are acceptable it would be useful to me to get this up into chocolatey.

Chris.